### PR TITLE
Update the GitHub base URL to append 2019 for the current version

### DIFF
--- a/outside-test.sh
+++ b/outside-test.sh
@@ -4,7 +4,7 @@ if (( $# != 1 )); then
   echo "Which repo shall I test?"
   exit 1
 fi
-REPO="https://github.com/ukc-co663/dependency-solver-$1"
+REPO="https://github.com/ukc-co663/dependency-solver-2019-$1"
 chmod -R +w temp-playground
 rm -rf temp-playground
 cp -r tests temp-playground


### PR DESCRIPTION
The URLs are now built like 'ukc-co663/dependency-solver-2019-$user'.

Fixes #9